### PR TITLE
Group async calls in bootstrapping for more concurrency

### DIFF
--- a/managers/BootstrapManager.go
+++ b/managers/BootstrapManager.go
@@ -104,15 +104,12 @@ func GetFirstBootstrapData(collegeID, proID string) BootstrapData {
 		allProTeams = GetAllNFLTeams()
 	}()
 
-	wg.Wait()
-
 	if len(collegeID) > 0 {
-		wg.Add(3)
+		wg.Add(6)
 		go func() {
 			defer wg.Done()
 			collegeTeam = GetTeamByTeamID(collegeID)
 		}()
-
 		go func() {
 			defer wg.Done()
 			collegePlayers = GetAllCollegePlayers()
@@ -121,16 +118,11 @@ func GetFirstBootstrapData(collegeID, proID string) BootstrapData {
 			injuredCollegePlayers = MakeCollegeInjuryList(collegePlayers)
 			portalPlayers = MakeCollegePortalList(collegePlayers)
 			mu.Unlock()
-
 		}()
 		go func() {
 			defer wg.Done()
 			collegeNotifications = GetNotificationByTeamIDAndLeague("CFB", collegeID)
 		}()
-
-		wg.Wait()
-
-		wg.Add(3)
 		go func() {
 			defer wg.Done()
 			cfbStats := GetCollegePlayerSeasonStatsBySeason(seasonID, gtStr)
@@ -142,7 +134,6 @@ func GetFirstBootstrapData(collegeID, proID string) BootstrapData {
 			topReceivers = getCFBOrderedListByStatType("RECEIVING", collegeTeam.ID, cfbStats, collegePlayerMap)
 			mu.Unlock()
 		}()
-
 		go func() {
 			defer wg.Done()
 			collegeGameplan = GetGameplanByTeamID(collegeID)
@@ -152,8 +143,6 @@ func GetFirstBootstrapData(collegeID, proID string) BootstrapData {
 			collegeDepthChart = GetDepthchartByTeamID(collegeID)
 
 		}()
-
-		wg.Wait()
 	}
 	if len(proID) > 0 {
 		wg.Add(3)
@@ -170,17 +159,15 @@ func GetFirstBootstrapData(collegeID, proID string) BootstrapData {
 			defer wg.Done()
 			proGameplan = GetNFLGameplanByTeamID(proID)
 		}()
-		wg.Wait()
 	}
 
 	wg.Add(1)
-
 	go func() {
 		defer wg.Done()
 		faceDataMap = GetAllFaces()
 	}()
 
-	wg.Wait()
+	wg.Wait() 
 	return BootstrapData{
 		CollegeTeam:          collegeTeam,
 		AllCollegeTeams:      allCollegeTeams,
@@ -258,8 +245,7 @@ func GetSecondBootstrapData(collegeID, proID string) BootstrapDataTwo {
 			collegeStandings = GetAllCollegeStandingsBySeasonID(strconv.Itoa(int(ts.CollegeSeasonID)))
 			log.Println("Fetched College Standings, count:", len(collegeStandings))
 		}()
-		wg.Wait()
-		log.Println("Completed all College data queries.")
+		log.Println("Initiated all College data queries.")
 
 	}
 	if len(proID) > 0 {
@@ -301,8 +287,9 @@ func GetSecondBootstrapData(collegeID, proID string) BootstrapDataTwo {
 			log.Println("Fetched NFL Players, roster count:", len(proRosterMap), "injured count:", len(injuredProPlayers))
 		}()
 
+		log.Println("Initiated all Pro data queries.")
 		wg.Wait()
-		log.Println("Completed all Pro data queries.")
+		log.Println("Completed all football data queries.")
 	}
 	return BootstrapDataTwo{
 		CollegeStandings:     collegeStandings,
@@ -352,9 +339,8 @@ func GetThirdBootstrapData(collegeID, proID string) BootstrapDataThree {
 			collegeDCs := GetAllCollegeDepthcharts()
 			collegeDepthChartMap = MakeCollegeDepthChartMap(collegeDCs)
 		}()
-
-		wg.Wait()
 	}
+
 	if len(proID) > 0 {
 		wg.Add(6)
 


### PR DESCRIPTION
Changed the waitgroup behavior in the NFL bootstrapping to start all concurrent functions at once instead of waiting for each group to finish. I wasn't sure if there was some reason that it was done in separate waitgroups, but the calls don't appear to be dependent on each other, and the responses still seem correct at a glance.

It doesn't seem to have saved much time on the second or third bootstraps, but I think the longer DB calls in the first bootstrap (get all players, get player faces) benefit more from the concurrency.

Performance results in local testing:
- Bootstrap one:
  - Main branch: 4768ms
![image](https://github.com/user-attachments/assets/2e68ecb6-0b92-481a-8aab-be82fb0c4b17)
  - With changes: 3321ms
![image](https://github.com/user-attachments/assets/a0709e09-b4e0-4cdc-8f94-d27458e0d737)
- Bootstrap two:
  - Main branch: 1346ms
![image](https://github.com/user-attachments/assets/c20d551f-3d2a-4810-9b22-dcf78e94a608)
  - With changes: 1333ms
![image](https://github.com/user-attachments/assets/1fb632b0-1e29-4536-8b46-06018f36c3c7)
- Bootstrap three:
  - Main branch: 2782ms
![image](https://github.com/user-attachments/assets/b6ae6308-1593-4804-a062-7298fbe04c29)
  - With changes: 2668ms
![image](https://github.com/user-attachments/assets/992e39ca-ba76-4c45-a70e-4e601de30a14)

