### PR TITLE
Implement Training Camp as API call

### DIFF
--- a/controller/TrainingCampController.go
+++ b/controller/TrainingCampController.go
@@ -5,11 +5,18 @@ import (
 	"net/http"
 
 	"github.com/CalebRose/SimFBA/managers"
+	"github.com/gorilla/mux"
 )
 
 // GetAllCollegeTeamsForRosterPage
 func RunTrainingCamps(w http.ResponseWriter, r *http.Request) {
-	managers.RunTrainingCamps()
+	vars := mux.Vars(r)
+	year := vars["year"]
+	err := managers.RunTrainingCamps(year)
 
-	json.NewEncoder(w).Encode("Training Camp Complete")
+	if err != nil {
+		json.NewEncoder(w).Encode(err.Error())
+	} else {
+		json.NewEncoder(w).Encode("Training Camp Complete")
+	}
 }

--- a/controller/TrainingCampController.go
+++ b/controller/TrainingCampController.go
@@ -8,8 +8,8 @@ import (
 )
 
 // GetAllCollegeTeamsForRosterPage
-func UploadTrainingCampCSVData(w http.ResponseWriter, r *http.Request) {
-	managers.UploadTrainingCampCSV()
+func RunTrainingCamps(w http.ResponseWriter, r *http.Request) {
+	managers.RunTrainingCamps()
 
 	json.NewEncoder(w).Encode("Training Camp Complete")
 }

--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func handleRequests() http.Handler {
 	apiRouter.HandleFunc("/trades/nfl/proposal/cancel/{proposalID}", controller.CancelTradeOffer).Methods("GET")
 
 	// Training Camp
-	apiRouter.HandleFunc("/nfl/training/camp/upload", controller.UploadTrainingCampCSVData).Methods("GET")
+	apiRouter.HandleFunc("/nfl/training/camp", controller.RunTrainingCamps).Methods("GET")
 
 	// Transfer Intentions
 	apiRouter.HandleFunc("/simfba/sync/transfer/intention", controller.ProcessTransferIntention).Methods("GET")

--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func handleRequests() http.Handler {
 	apiRouter.HandleFunc("/trades/nfl/proposal/cancel/{proposalID}", controller.CancelTradeOffer).Methods("GET")
 
 	// Training Camp
-	apiRouter.HandleFunc("/nfl/training/camp", controller.RunTrainingCamps).Methods("GET")
+	apiRouter.HandleFunc("/nfl/training/camp/{year}", controller.RunTrainingCamps).Methods("GET")
 
 	// Transfer Intentions
 	apiRouter.HandleFunc("/simfba/sync/transfer/intention", controller.ProcessTransferIntention).Methods("GET")

--- a/managers/TrainingCampManager.go
+++ b/managers/TrainingCampManager.go
@@ -1,13 +1,20 @@
 package managers
 
 import (
-	"github.com/CalebRose/SimFBA/dbprovider"
-	"github.com/CalebRose/SimFBA/repository"
+	"bufio"
+	"encoding/csv"
+	"log"
+	"math/rand/v2"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
 	"github.com/CalebRose/SimFBA/structs"
 	"github.com/CalebRose/SimFBA/util"
 )
 
-func UploadTrainingCampCSV() {
+/*func UploadTrainingCampCSV() {
 	db := dbprovider.GetInstance().GetDB()
 
 	teamPath := "C:\\Users\\ctros\\go\\src\\github.com\\CalebRose\\SimFBA\\data\\2025\\2025_simnfl_rookie_camp_results.csv"
@@ -55,4 +62,885 @@ func UploadTrainingCampCSV() {
 
 		repository.SaveNFLPlayer(nflPlayer, db)
 	}
+}*/
+
+func RunTrainingCamps() {
+	//readPath := "C:\\Users\\ctros\\go\\src\\github.com\\CalebRose\\SimFBA\\data\\2026\\trainingcamp.csv"
+	readPath := "C:\\Code\\SimSN\\SimFBA\\data\\2026\\trainingcamp.csv"
+	writePath := "C:\\Code\\SimSN\\SimFBA\\data\\2026\\trainingcamp_results.csv"
+
+	drillSelectionsCSV := util.ReadCSV(readPath)
+
+	drillResultsCSV, err := os.Create(writePath)
+	if err != nil {
+		panic(err)
+	}
+
+	csvWriter := csv.NewWriter(bufio.NewWriter(drillResultsCSV))
+
+	csvWriter.Write([]string{"Team", "DrillPosition", "Archetype", "FirstName", "LastName", "PositionDrill", "PositionDrillAttribute", "PositionDrillResult", "TeamDrill", "TeamDrillAttribute",
+		"TeamDrillResult", "EventText", "InjuryText", "WeeksOut", "FootballIQ", "Speed", "Carrying", "Agility", "Catching", "RouteRunning", "ZoneCoverage", "ManCoverage", "Strength",
+		"Tackle", "PassBlock", "RunBlock", "PassRush", "RunDefense", "ThrowPower", "ThrowAccuracy", "KickAccuracy", "KickPower", "PuntAccuracy", "PuntPower"})
+
+	defer drillResultsCSV.Close()
+	defer csvWriter.Flush()
+
+	for idx, row := range drillSelectionsCSV {
+		if idx == 0 {
+			continue
+		}
+
+		teamId := row[0]
+
+		players := GetNFLPlayersWithContractsByTeamID(teamId)
+
+		positionOverrides := getPositionOverrides(strings.ToLower(row[13]))
+
+		for _, player := range players {
+			drillPosition := player.Position
+			drillArchetype := player.Archetype
+			if (slices.Contains(positionOverrides, strings.ToLower(player.FirstName+player.LastName)) && player.PositionTwo != "") || player.Position == "ATH" {
+				drillPosition = player.PositionTwo
+				drillArchetype = player.ArchetypeTwo
+			}
+
+			positionDrill := getPositionDrill(drillPosition, row, player)
+			teamDrill := row[12]
+
+			runDrills(player, drillPosition, drillArchetype, positionDrill, teamDrill, csvWriter)
+		}
+	}
+}
+
+func runDrills(player structs.NFLPlayer, drillPosition string, drillArchetype string, positionDrill string, teamDrill string, csvWriter *csv.Writer) {
+	positionDrillAttribute := getAttribute(drillPosition, drillArchetype, positionDrill)
+	teamDrillAttribute := getAttribute(drillPosition, drillArchetype, teamDrill)
+
+	log.Printf("Running drills for: %s %s %s %s %s. Position Drill: %s (attr: %s), Team Drill: %s (attr: %s)\n",
+		player.TeamAbbr, drillArchetype, drillPosition, player.FirstName, player.LastName, positionDrill, positionDrillAttribute, teamDrill, teamDrillAttribute)
+
+	eventModifier := getEventModifier(player)
+	eventText := ""
+	if eventModifier != 0 {
+		eventText = events[0][eventModifier][rand.IntN(len(events[0][eventModifier]))]
+		log.Printf("Camp event occurred for %s %s %s %s: %s Modifier: %d\n", player.TeamAbbr, player.Position, player.FirstName, player.LastName, eventText, eventModifier)
+	}
+
+	injuryText, injuryWeeks := checkInjury(player)
+	if injuryWeeks > 0 {
+		log.Printf("%s %s %s %s suffered an injury during minicamp! %s, out for %d weeks.\n", player.TeamAbbr, player.Position, player.FirstName, player.LastName, injuryText, injuryWeeks)
+	}
+
+	changedAttrs := &structs.CollegePlayerProgressions{
+		FootballIQ:      player.FootballIQ,
+		Speed:           player.Speed,
+		Carrying:        player.Carrying,
+		Agility:         player.Agility,
+		Catching:        player.Catching,
+		RouteRunning:    player.RouteRunning,
+		ZoneCoverage:    player.ZoneCoverage,
+		ManCoverage:     player.ManCoverage,
+		Strength:        player.Strength,
+		Tackle:          player.Tackle,
+		PassBlock:       player.PassBlock,
+		RunBlock:        player.RunBlock,
+		PassRush:        player.PassRush,
+		RunDefense:      player.RunDefense,
+		ThrowPower:      player.ThrowPower,
+		ThrowAccuracy:   player.ThrowAccuracy,
+		KickAccuracy:    player.KickAccuracy,
+		KickPower:       player.KickPower,
+		PuntAccuracy:    player.PuntAccuracy,
+		PuntPower:       player.PuntPower,
+		InjuryText:      injuryText,
+		WeeksOfRecovery: injuryWeeks,
+	}
+
+	positionDrillResult := getDrillResult(player, eventModifier)
+	log.Printf("Position Drill Result for %s %s %s %s: %s (attr: %s) Result: %d\n", player.TeamAbbr, player.Position, player.FirstName, player.LastName, positionDrill, positionDrillAttribute, positionDrillResult)
+	teamDrillResult := getDrillResult(player, eventModifier)
+	log.Printf("Team Drill Result for %s %s %s %s: %s (attr: %s) Result: %d\n", player.TeamAbbr, player.Position, player.FirstName, player.LastName, teamDrill, teamDrillAttribute, teamDrillResult)
+
+	applyDrillResult(changedAttrs, positionDrillAttribute, positionDrillResult)
+	applyDrillResult(changedAttrs, teamDrillAttribute, teamDrillResult)
+
+	csvWriter.Write([]string{player.TeamAbbr, drillPosition, drillArchetype, player.FirstName, player.LastName, positionDrill, positionDrillAttribute,
+		strconv.Itoa(positionDrillResult), teamDrill, teamDrillAttribute, strconv.Itoa(teamDrillResult), eventText, injuryText,
+		strconv.Itoa(injuryWeeks), strconv.Itoa(changedAttrs.FootballIQ), strconv.Itoa(changedAttrs.Speed),
+		strconv.Itoa(changedAttrs.Carrying), strconv.Itoa(changedAttrs.Agility), strconv.Itoa(changedAttrs.Catching),
+		strconv.Itoa(changedAttrs.RouteRunning), strconv.Itoa(changedAttrs.ZoneCoverage), strconv.Itoa(changedAttrs.ManCoverage),
+		strconv.Itoa(changedAttrs.Strength), strconv.Itoa(changedAttrs.Tackle), strconv.Itoa(changedAttrs.PassBlock),
+		strconv.Itoa(changedAttrs.RunBlock), strconv.Itoa(changedAttrs.PassRush), strconv.Itoa(changedAttrs.RunDefense),
+		strconv.Itoa(changedAttrs.ThrowPower), strconv.Itoa(changedAttrs.ThrowAccuracy), strconv.Itoa(changedAttrs.KickAccuracy),
+		strconv.Itoa(changedAttrs.KickPower), strconv.Itoa(changedAttrs.PuntAccuracy), strconv.Itoa(changedAttrs.PuntPower)},
+	)
+}
+
+func getPositionOverrides(overrides string) []string {
+	if overrides == "" {
+		return []string{}
+	}
+	// Player names should ideally be formatted as FirstnameLastname and spaces in between, so they can be treated as part of the same column of the CSV.
+	return strings.Split(overrides, " ")
+}
+
+func getPositionDrill(drillPosition string, row []string, player structs.NFLPlayer) string {
+	switch drillPosition {
+	case "QB":
+		return row[1]
+	case "RB":
+		return row[2]
+	case "FB":
+		return row[3]
+	case "TE":
+		return row[4]
+	case "WR":
+		return row[5]
+	case "OT", "OG", "C":
+		return row[6]
+	case "DT", "DE":
+		return row[7]
+	case "ILB":
+		return row[8]
+	case "OLB":
+		if player.Archetype == "Pass Rush" {
+			return row[7]
+		} else {
+			return row[8]
+		}
+	case "CB":
+		return row[9]
+	case "FS", "SS":
+		return row[10]
+	case "K", "P":
+		return row[11]
+	default:
+		return "tackle"
+	}
+}
+
+func getEventModifier(player structs.NFLPlayer) int {
+	discipline := float32(player.Discipline)
+
+	negative := (-.6 * discipline) + 60
+	positive := (.6 * discipline) + negative
+
+	// Older veterans are more acclimated to the NFL and are less likely to have camp events, positive or negative.
+	if player.Experience > 2 {
+		negative = negative / 2
+		positive = positive / 2
+	} else if player.Experience > 5 {
+		negative = negative / 4
+		positive = positive / 4
+	}
+
+	eventRoll := float32(rand.IntN(100))
+	if eventRoll < negative {
+		eventSeverity := rand.IntN(100)
+		if eventSeverity < 60 {
+			return -1
+		} else if eventSeverity < 90 {
+			return -2
+		} else {
+			return -3
+		}
+	} else if eventRoll < positive {
+		eventSeverity := rand.IntN(100)
+		if eventSeverity < 60 {
+			return 1
+		} else if eventSeverity < 90 {
+			return 2
+		} else {
+			return 3
+		}
+	}
+	// no event
+	return 0
+}
+
+// Build global dictionary of events
+var events = []map[int][]string{
+	{
+		3: {"Dominates in drills, consistently outperforming expectations.",
+			"Takes the lead in drills, setting the pace for others to follow.",
+			"Emerges as an early standout in minicamp reports.",
+			"Impresses coaching staff with natural leadership skills during team huddles.",
+			"Consistently executes plays at a high level, earning trust from the coaching staff."},
+		2: {"Receives praise in team meetings for attention to detail.",
+			"Quickly picks up the playbook and shows understanding in practice.",
+			"Earns a shout-out in a press conference from the head coach.",
+			"Demonstrates unexpected versatility by excelling in an unfamiliar role.",
+			"Sets a strong example for fellow rookies with a positive attitude and work ethic."},
+		1: {"Impresses position coach with consistent effort.",
+			"Completes all conditioning drills without issue.",
+			"Makes a solid play during a scrimmage.",
+			"Responds well to coaching, quickly implementing feedback.",
+			"Consistently shows good sportsmanship and camaraderie with teammates."},
+		-1: {"Shows up late to a team meeting.",
+			"Struggles with conditioning drills.",
+			"Misses a minor assignment in a scrimmage and gets yelled at by a coach over it.",
+			"Gets unusually frustrated after losing a rep in individual drills.",
+			"Position coaches completly forget his name."},
+		-2: {"Blows a key play during a scrimmage in front of the coaching staff.",
+			"Gets called out in team meetings for lack of focus.",
+			"Struggles with communication and timing on the field.",
+			"Repeatedly forgets assignments, slowing down drills for others.",
+			"Performs poorly in conditioning, noticeably lagging behind teammates."},
+		-3: {"Misses multiple meetings or practices without an excuse, causing a formal warning from the team.",
+			"Has an on-field meltdown during a scrimmage, leading to being pulled from practice.",
+			"Publicly criticizes coaching decisions during interviews, damaging relationships with the staff.",
+			"Consistently fails to execute assignments, prompting questions about future roster status.",
+			"Demonstrates reckless behavior off the field, sparking disciplinary actions."},
+	},
+}
+
+func checkInjury(player structs.NFLPlayer) (string, int) {
+	injuryCheck := rand.IntN(1000)
+	if injuryCheck < 25 {
+		return getInjuryDetails(player)
+	}
+	return "None", 0
+}
+
+func getInjuryDetails(player structs.NFLPlayer) (string, int) {
+	injuryRoll := getInjuryRoll()
+	weeksOut := 0
+
+	if injuryRoll == 10 {
+		weeksOut = rand.IntN(20) + 1
+	} else {
+		// results in a range from 0-15, spread roughly evenly across injury ratings from 0-100
+		injuryModifier := int((100.0 - float32(player.Injury)) / 6.67)
+		weeksOut = injuryTimes[injuryRoll][15-injuryModifier]
+	}
+
+	severity := getInjurySeverity(weeksOut)
+
+	return getInjuryText(severity), weeksOut
+}
+
+func getInjuryRoll() int {
+	roll := rand.IntN(1000)
+
+	if roll < 21 {
+		return 0
+	} else if roll < 83 {
+		return 1
+	} else if roll < 166 {
+		return 2
+	} else if roll < 270 {
+		return 3
+	} else if roll < 416 {
+		return 4
+	} else if roll < 583 {
+		return 5
+	} else if roll < 729 {
+		return 6
+	} else if roll < 833 {
+		return 7
+	} else if roll < 916 {
+		return 8
+	} else if roll < 978 {
+		return 9
+	} else {
+		return 10
+	}
+}
+
+var injuryTimes = [][16]int{
+	{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+	{13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0},
+	{11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0},
+	{9, 8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0, 0, 0},
+	{7, 7, 6, 5, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0, 0, 0},
+	{5, 5, 4, 4, 3, 3, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0},
+	{6, 6, 5, 4, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+	{8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0},
+	{10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0, 0},
+	{12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0},
+}
+
+func getInjurySeverity(weeksOut int) string {
+	if weeksOut < 3 {
+		return "Minor"
+	} else if weeksOut < 7 {
+		return "Moderate"
+	} else if weeksOut < 13 {
+		return "Severe"
+	} else {
+		return "Season Ending"
+	}
+}
+
+func getInjuryText(severity string) string {
+	switch severity {
+	case "Minor":
+		return minorInjuries[rand.IntN(len(minorInjuries))]
+	case "Moderate":
+		return moderateInjuries[rand.IntN(len(moderateInjuries))]
+	case "Severe":
+		return severeInjuries[rand.IntN(len(severeInjuries))]
+	case "Season Ending":
+		return seasonEndingInjuries[rand.IntN(len(seasonEndingInjuries))]
+	}
+	return "Unknown Injury"
+}
+
+func getDrillResult(player structs.NFLPlayer, eventModifier int) int {
+	badDrillThreshold := 5
+	neutralDrillThreshold := 15
+	okayDrillThreshold := 50
+	goodDrillThreshold := 80
+
+	// Older veterans are less likely to have major breakthroughs at camp
+	if player.Experience >= 5 {
+		badDrillThreshold = 5
+		neutralDrillThreshold = 40
+		okayDrillThreshold = 80
+		goodDrillThreshold = 95
+	}
+
+	result := 0
+	drillRoll := rand.IntN(100)
+	if drillRoll < badDrillThreshold {
+		result = -1
+	} else if drillRoll < neutralDrillThreshold {
+		result = 0
+	} else if drillRoll < okayDrillThreshold {
+		result = 1
+	} else if drillRoll < goodDrillThreshold {
+		result = 2
+	} else {
+		// great drill result
+		result = 3
+	}
+
+	return result + eventModifier
+}
+
+func applyDrillResult(progression *structs.CollegePlayerProgressions, attribute string, modifier int) {
+	if attribute == "football_iq" {
+		progression.FootballIQ += modifier
+	}
+	if attribute == "speed" {
+		progression.Speed += modifier
+	}
+	if attribute == "carrying" {
+		progression.Carrying += modifier
+	}
+	if attribute == "agility" {
+		progression.Agility += modifier
+	}
+	if attribute == "catching" {
+		progression.Catching += modifier
+	}
+	if attribute == "route_running" {
+		progression.RouteRunning += modifier
+	}
+	if attribute == "zone_coverage" {
+		progression.ZoneCoverage += modifier
+	}
+	if attribute == "man_coverage" {
+		progression.ManCoverage += modifier
+	}
+	if attribute == "strength" {
+		progression.Strength += modifier
+	}
+	if attribute == "tackle" {
+		progression.Tackle += modifier
+	}
+	if attribute == "pass_block" {
+		progression.PassBlock += modifier
+	}
+	if attribute == "run_block" {
+		progression.RunBlock += modifier
+	}
+	if attribute == "pass_rush" {
+		progression.PassRush += modifier
+	}
+	if attribute == "run_defense" {
+		progression.RunDefense += modifier
+	}
+	if attribute == "throw_power" {
+		progression.ThrowPower += modifier
+	}
+	if attribute == "throw_accuracy" {
+		progression.ThrowAccuracy += modifier
+	}
+	if attribute == "kick_accuracy" {
+		progression.KickAccuracy += modifier
+	}
+	if attribute == "kick_power" {
+		progression.KickPower += modifier
+	}
+	if attribute == "punt_accuracy" {
+		progression.PuntAccuracy += modifier
+	}
+	if attribute == "punt_power" {
+		progression.PuntPower += modifier
+	}
+}
+
+// Returns which attribute to change
+func getAttribute(position string, archetype string, drill string) string {
+	if drill == "speed" {
+		return "speed"
+	} else if drill == "lift" {
+		return "strength"
+	} else if drill == "film" {
+		return "football_iq"
+	} else if drill == "plyometrics" {
+		return "agility"
+	} else if position == "QB" {
+		if drill == "dropback" {
+			return "throw_power"
+		} else if drill == "screen" {
+			return "throw_accuracy"
+		} else if strings.Contains(drill, "pass") {
+			if archetype == "Pocket" || archetype == "Balanced" {
+				return "throw_power"
+			} else {
+				return "throw_accuracy"
+			}
+		} else {
+			if archetype == "Pocket" || archetype == "Balanced" {
+				return "throw_accuracy"
+			} else {
+				return "throw_power"
+			}
+		}
+	} else if position == "RB" {
+		if drill == "gauntlet" {
+			return "carrying"
+		} else if drill == "square" {
+			return "route_running"
+		} else if drill == "blitzpickup" {
+			return "pass_block"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if strings.Contains(drill, "pass") {
+			switch archetype {
+			case "Speed", "Balanced":
+				return "catching"
+			case "Power":
+				return "pass_block"
+			default:
+				return "route_running"
+			}
+		} else {
+			switch archetype {
+			case "Power":
+				return "strength"
+			case "Receiving":
+				return "agility"
+			default:
+				chance := rand.IntN(2)
+				if chance == 0 {
+					return "strength"
+				}
+				return "agility"
+			}
+		}
+	} else if position == "FB" {
+		if drill == "gauntlet" {
+			return "carrying"
+		} else if drill == "square" {
+			return "route_running"
+		} else if drill == "blitzpickup" {
+			return "pass_block"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if drill == "lead" {
+			return "run_block"
+		} else if strings.Contains(drill, "pass") {
+			if archetype == "Blocking" {
+				return "pass_block"
+			} else {
+				return "catching"
+			}
+		} else {
+			switch archetype {
+			case "Blocking":
+				return "run_block"
+			case "Rushing":
+				return "strength"
+			case "Receiving":
+				return "agility"
+			default:
+				chance := rand.IntN(3)
+				if chance == 0 {
+					return "strength"
+				}
+				if chance == 1 {
+					return "run_block"
+				}
+				return "agility"
+			}
+		}
+	} else if position == "TE" {
+		if drill == "gauntlet" {
+			return "carrying"
+		} else if drill == "square" {
+			return "route_running"
+		} else if drill == "blitzpickup" {
+			return "pass_block"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if drill == "arc" {
+			return "run_block"
+		} else if strings.Contains(drill, "pass") {
+			switch archetype {
+			case "Blocking":
+				return "pass_block"
+			case "Vertical Threat":
+				return "speed"
+			default:
+				return "catching"
+			}
+		} else {
+			return "run_block"
+		}
+	} else if position == "WR" {
+		if drill == "gauntlet" {
+			return "carrying"
+		} else if drill == "square" {
+			return "route_running"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if drill == "screenblock" {
+			return "run_block"
+		} else if strings.Contains(drill, "pass") {
+			switch archetype {
+			case "Possession", "Red Zone Threat":
+				return "catching"
+			case "Speed":
+				return "speed"
+			default:
+				return "route_running"
+			}
+		} else {
+			return "run_block"
+		}
+	} else if position == "OT" {
+		if drill == "mirror" {
+			return "pass_block"
+		} else if drill == "sled" {
+			return "run_block"
+		} else if strings.Contains(drill, "pass") {
+			return "pass_block"
+		} else {
+			return "run_block"
+		}
+	} else if position == "OG" {
+		if drill == "mirror" {
+			return "pass_block"
+		} else if drill == "sled" {
+			return "run_block"
+		} else if strings.Contains(drill, "pass") {
+			return "pass_block"
+		} else {
+			return "run_block"
+		}
+	} else if position == "C" {
+		if drill == "mirror" {
+			return "pass_block"
+		} else if drill == "sled" {
+			return "run_block"
+		} else if strings.Contains(drill, "pass") {
+			return "pass_block"
+		} else {
+			return "run_block"
+		}
+	} else if position == "DT" {
+		if drill == "rip" {
+			return "pass_rush"
+		} else if drill == "shed" {
+			return "run_defense"
+		} else if strings.Contains(drill, "pass") {
+			return "pass_rush"
+		} else {
+			return "run_defense"
+		}
+	} else if position == "DE" {
+		if drill == "rip" {
+			return "pass_rush"
+		} else if drill == "shed" {
+			return "run_defense"
+		} else if strings.Contains(drill, "pass") {
+			return "pass_rush"
+		} else {
+			return "run_defense"
+		}
+	} else if position == "OLB" {
+		// EDGE
+		if archetype == "Pass Rush" || archetype == "Run Stopper" {
+			if drill == "rip" {
+				return "pass_rush"
+			} else if drill == "shed" {
+				return "run_defense"
+			} else if strings.Contains(drill, "pass") {
+				return "pass_rush"
+			} else {
+				return "run_defense"
+			}
+			// Off Ball
+		} else {
+			if drill == "runfit" {
+				return "run_defense"
+			} else if drill == "rushlane" {
+				return "pass_rush"
+			} else if drill == "zonedrop" {
+				return "zone_coverage"
+			} else if drill == "hipturn" {
+				return "man_coverage"
+			} else if strings.Contains(drill, "pass") {
+				chance := rand.IntN(2)
+				if chance == 0 {
+					return "zone_coverage"
+				}
+				return "man_coverage"
+			} else {
+				return "run_defense"
+			}
+		}
+	} else if position == "ILB" {
+		if drill == "runfit" {
+			return "run_defense"
+		} else if drill == "rushlane" {
+			return "pass_rush"
+		} else if drill == "zonedrop" {
+			return "zone_coverage"
+		} else if drill == "hipturn" {
+			return "man_coverage"
+		} else if strings.Contains(drill, "pass") {
+			chance := rand.IntN(2)
+			if chance == 0 {
+				return "zone_coverage"
+			}
+			return "man_coverage"
+		} else {
+			return "run_defense"
+		}
+	} else if position == "CB" {
+		if drill == "zonedrop" {
+			return "zone_coverage"
+		} else if drill == "hipturn" {
+			return "man_coverage"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if strings.Contains(drill, "pass") {
+			switch archetype {
+			case "Man Coverage":
+				return "man_coverage"
+			case "Zone Coverage":
+				return "zone_coverage"
+			default:
+				chance := rand.IntN(2)
+				if chance == 0 {
+					return "zone_coverage"
+				}
+				return "man_coverage"
+			}
+		} else {
+			return "tackle"
+		}
+	} else if position == "FS" {
+		if drill == "centerfield" {
+			return "zone_coverage"
+		} else if drill == "match" {
+			return "man_coverage"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if drill == "alley" {
+			return "run_defense"
+		} else if drill == "handcombat" {
+			return "pass_rush"
+		} else if strings.Contains(drill, "pass") {
+			switch archetype {
+			case "Man Coverage":
+				return "man_coverage"
+			case "Zone Coverage":
+				return "zone_coverage"
+			default:
+				chance := rand.IntN(2)
+				if chance == 0 {
+					return "zone_coverage"
+				}
+				return "man_coverage"
+			}
+		} else {
+			return "tackle"
+		}
+	} else if position == "SS" {
+		if drill == "centerfield" {
+			return "zone_coverage"
+		} else if drill == "match" {
+			return "man_coverage"
+		} else if drill == "jugs" {
+			return "catching"
+		} else if drill == "alley" {
+			return "run_defense"
+		} else if drill == "handcombat" {
+			return "pass_rush"
+		} else if strings.Contains(drill, "pass") {
+			switch archetype {
+			case "Man Coverage":
+				return "man_coverage"
+			case "Zone Coverage":
+				return "zone_coverage"
+			default:
+				chance := rand.IntN(2)
+				if chance == 0 {
+					return "zone_coverage"
+				}
+				return "man_coverage"
+			}
+		} else {
+			return "tackle"
+		}
+	} else if position == "K" {
+		switch drill {
+		case "accuracy":
+			return "kick_accuracy"
+		case "power":
+			return "kick_power"
+		default:
+			return "football_iq"
+		}
+	} else if position == "P" {
+		switch drill {
+		case "accuracy":
+			return "punt_accuracy"
+		case "power":
+			return "punt_power"
+		default:
+			return "football_iq"
+		}
+	}
+	return "bad position"
+}
+
+var minorInjuries = []string{
+	"Illness",
+	"Stinger",
+	"Strained Biceps",
+	"Strained Triceps",
+	"Bruised Foot",
+	"Sprained Foot",
+	"Bruised Hip",
+	"Strained Hip",
+	"Strained Groin",
+	"Strained Calf",
+	"Strained Quadriceps",
+	"Sprained Wrist",
+	"Elbow Tendonitis",
+	"Bruised Elbow",
+	"Sprained Elbow",
+	"Strained Back",
+	"Hyperextended Back",
+	"Ankle Bruise",
+	"Ankle Sprain",
+	"Strained Shoulder",
+	"Shoulder Tendonitis",
+	"Separated Shoulder",
+	"Sprained Thumb",
+	"Sprained Knee",
+	"Concussion",
+}
+
+var moderateInjuries = []string{
+	"Lacerated Spleen",
+	"Fractured Toe",
+	"Dislocated Toe",
+	"Bruised Toe",
+	"Sprained Toe",
+	"Turf Toe",
+	"Wrist Bruise",
+	"Sprained Wrist",
+	"Hip Strain",
+	"Fractured Ribs",
+	"Achilles Tendonitis",
+	"Bruised Achilles",
+	"Dislocated Elbow",
+	"Elbow Tendonitis",
+	"Sprained Elbow",
+	"Strained Groin",
+	"Pulled Groin",
+	"Strained Calf",
+	"Pulled Calf",
+	"Bruised Thumb",
+	"Sprained Thumb",
+	"Dislocated Thumb",
+	"Fractured Thumb",
+	"MCL Bruise",
+	"PCL Bruise",
+	"Patellar Tendon Bruise",
+	"Strained Quadriceps",
+	"Pulled Quadriceps",
+	"Concussion",
+	"Strained Biceps",
+	"Pulled Biceps",
+	"Strained Triceps",
+	"Pulled Triceps",
+	"Strained Pectoral",
+	"Pulled Pectoral",
+	"High Ankle Sprain",
+	"Bruised Hamstring",
+	"Pulled Hamstring",
+	"Neck Bruise",
+	"Sprained Neck",
+	"ACL Bruise",
+	"Dislocated Shoulder",
+	"Shoulder Tendonitis",
+	"Separated Shoulder",
+	"Sprained Rotator Cuff",
+	"Dislocated Ankle",
+	"Dislocated Foot",
+	"Sprained Foot",
+	"Back Disk Tear",
+}
+
+var severeInjuries = []string{
+	"Biceps Tear",
+	"Triceps Tear",
+	"Quadriceps Tear",
+	"MCL Bruise",
+	"MCL Tendonitis",
+	"PCL Bruise",
+	"PCL Tendonitis",
+	"Patellar Tendon Bruise",
+	"Patellar Tendonitis",
+	"Knee Meniscus Bruise",
+	"Knee Meniscus Tear",
+	"Achilles Tendonitis",
+	"Hamstring Tendonitis",
+	"Fractured Wrist",
+	"Fractured Jaw",
+	"ACL Bruise",
+	"ACL Tendonitis",
+	"Calf Tear",
+	"Groin Tear",
+	"Pulled Pectoral",
+	"Pectoral Tear",
+	"Fractured Ribs",
+	"Sprained Neck",
+	"Back Disk Tear",
+	"Fractured Ankle",
+	"Fractured Foot",
+	"Strained Rotator Cuff",
+}
+
+var seasonEndingInjuries = []string{
+	"Ruptured Hamstring",
+	"Patellar Tendon Tear",
+	"Knee Meniscus Tear",
+	"Fractured Foot",
+	"Ruptured Achilles",
+	"MCL Tear",
+	"PCL Tear",
+	"Fractured Hip",
+	"Fractured Spine",
+	"Fractured Ankle",
+	"ACL Tear",
+	"Rotator Cuff Tear",
 }

--- a/managers/TrainingCampManager.go
+++ b/managers/TrainingCampManager.go
@@ -194,9 +194,9 @@ func runDrills(player structs.NFLPlayer, drillPosition string, drillArchetype st
 		strconv.Itoa(changedAttrs.ThrowPower), strconv.Itoa(changedAttrs.ThrowAccuracy), strconv.Itoa(changedAttrs.KickAccuracy),
 		strconv.Itoa(changedAttrs.KickPower), strconv.Itoa(changedAttrs.PuntAccuracy), strconv.Itoa(changedAttrs.PuntPower)},
 	)
-	// COMMENT THE BELOW 3 LINES IF YOU WANT TO TEST LOCALLY
 	player.ApplyTrainingCampInfo(*changedAttrs)
 	player.GetOverall()
+
 	repository.SaveNFLPlayer(player, db)
 }
 
@@ -829,7 +829,12 @@ func getAttribute(position string, archetype string, drill string) string {
 		case "power":
 			return "kick_power"
 		default:
-			return "football_iq"
+			// for team drills, pick a kicking attribute at random. K/P progressions could use the extra bonus.
+			if rand.IntN(2) == 0 {
+				return "kick_accuracy"
+			} else {
+				return "kick_power"
+			}
 		}
 	} else if position == "P" {
 		switch drill {
@@ -838,7 +843,12 @@ func getAttribute(position string, archetype string, drill string) string {
 		case "power":
 			return "punt_power"
 		default:
-			return "football_iq"
+			// for team drills, pick a punting attribute at random. K/P progressions could use the extra bonus.
+			if rand.IntN(2) == 0 {
+				return "punt_accuracy"
+			} else {
+				return "punt_power"
+			}
 		}
 	}
 	return "bad position"


### PR DESCRIPTION
This will run training camp code once a `trainingcamp.csv` is added to `/data/2026/`.

It functions similarly to the previous year's camp code, but with some modifications.
- Instead of a selection of rookies, every player on an NFL roster will participate in training camp. This includes players on practice squads.
- Teams will submit the drills they would like their players to perform via a Google Form.
- Drills will be selected by position group, instead of per individual player.
- Additionally, there will be one team drill that all players on the team participate in.
- The position groups are split as follows:
  - QB
  - RB
  - FB
  - WR
  - TE
  - OT, OG, C
  - DE, DT, Pass Rush OLB
  - OLB (except Pass Rush), ILB
  - CB
  - SS, FS
  - P, K
- The previous iteration of training camp also grouped Run Stopper OLBs with the defensive line, like with Pass Rushers. I don't know if Run Stoppers are intentionally modeled to be primarily 3-4 on-ball LBs, but the Old School defensive scheme has four down linemen and Run Stopper OLB as a scheme fit, so I feel like it makes more sense to have them practice with the rest of the off-ball LBs.
- For players with secondary positions, users may specify the names of the players they would like to practice with their secondary position on the Google form. If a user specifies a player without a secondary position, that selection will be ignored, and the player will work with their primary position as normal.
- The drill selection will be largely the same as in rookie minicamps last offseason, except with the addition of power and accuracy drills for the P and K positions.
- Like last year's rookie camps, each drill will affect its governed attribute for each player in a range of -1 to +3, and a chance for each player to have a camp event that further modifies their drill results an additional -3 to +3.
- However, more experienced players will have less of a chance of major changes via camp - the odds of drills increasing attributes by more than +1 for veterans are greatly decreased, and veterans will have significantly lower chances of triggering camp events.
  - The reasons for this change are threefold:
    - To provide more avenues of accelerating the development of young players and increase the ability to build quickly through the draft, as opposed to relying on trades and free agency for older players.
    - To ensure that the regression curves of aging players are not adversely affected by repeated large camp bonuses, making it less likely players can remain viable well past their prime ages.
    - To represent that experienced players are more acclimated to the NFL, and are less likely to have major developments at training camp compared to younger players.
  - Players with 5 years of NFL experience or less will have the standard drill result odds.
    - 5%: Bad drill, -1 to drilled attribute
    - 10%: Neutral drill, no change to drilled attribute
    - 35%: Okay drill, +1 to drilled attribute
    - 30%: Good drill, +2 to drilled attribute
    - 20%: Great drill, +3 to drilled attribute
  - Players with greater than 5 years of NFL experience will have much lower odds of highly positive drills results.
   - 5%: Bad drill
   - 35%: Neutral drill
   - 40%: Okay drill
   - 15% Good drill
   - 5% Great drill
 - The odds of camp events also vary by experience level. However, the odds of a camp event being good or bad and its magnitude remain the same as before, based on the player's discipline value.
   - 1st and 2nd year players will have the highest odds of camp events, matching last year's 60% standard.
   - 3rd-5th year players have a 30% chance of a camp event occurring.
   - Players with 6 or more years of NFL experience will have only a 15% chance of a camp event.
- As before, there is a chance players will get injured during training camp. As before, the chance of a player receiving an injury at camp is 0.25%. There were some minor modifications to the calculation of injury type and severity for the sake of code brevity, but should be very close to being functionally the same as before, with the injury severity affected by the player's injury rating.

I have attached some sample results of the training camps being run locally (with the code relevant to saving the changes to the DB omitted, so it wouldn't change anything for real), to provide a preview of what the results will look like when run for real.

[trainingcamp.csv](https://github.com/user-attachments/files/22052941/trainingcamp.csv)
[trainingcamp_results.csv](https://github.com/user-attachments/files/22052942/trainingcamp_results.csv)

If anyone wants to pull the branch and test locally, ensure that the `readPath` and `writePath` variables in `TrainingCampManager.RunTrainingCamps()`are pointed towards your local repository, then comment out the following lines of code in `TrainingCampManager.runDrills()` to ensure that no changes get saved to the live DB:
```
	player.ApplyTrainingCampInfo(*changedAttrs)
	player.GetOverall()

	repository.SaveNFLPlayer(player, db)
```