### PR TITLE
Fix punt and kickoff return yard narration

### DIFF
--- a/managers/StatsManager.go
+++ b/managers/StatsManager.go
@@ -1516,7 +1516,7 @@ func generateResultsString(play structs.PlayByPlay, playType string, participant
 		if play.IsTouchback {
 			firstSegment += " Touchback. "
 		} else {
-			resultYdsStr := strconv.Itoa(int(100 - play.ResultYards))
+			resultYdsStr := strconv.Itoa(int(play.ResultYards))
 			resultYards := util.GetYardsString(play.ResultYards)
 			firstSegment += recLabel + " returns the ball " + resultYdsStr + resultYards
 		}
@@ -1528,17 +1528,8 @@ func generateResultsString(play structs.PlayByPlay, playType string, participant
 		distanceStr := util.GetYardsString(play.KickDistance)
 		verb := " punts for "
 		firstSegment = kickerLabel + verb + strconv.Itoa(int(play.KickDistance)) + distanceStr
-		los := play.LineOfScrimmage
-		if los > 50 {
-			los = 100 - los
-		}
-		outside := los + play.KickDistance
-		netReturnYards := outside - play.ResultYards
-		resultYdsStr := strconv.Itoa(int(netReturnYards))
-		resultYards := util.GetYardsString(netReturnYards)
-		if !play.IsTouchback {
-			resultYdsStr = strconv.Itoa(int(netReturnYards))
-		}
+		resultYdsStr := strconv.Itoa(int(play.ResultYards))
+		resultYards := util.GetYardsString(play.ResultYards)
 
 		if play.IsBlocked {
 			blockerLabel := getPlayerLabel(participantMap[turnID])
@@ -1729,10 +1720,9 @@ func generateStreamString(play structs.PlayByPlay, playType, playName, poa strin
 		if play.IsTouchback {
 			firstSegment += util.GetTouchbackStatement()
 		} else {
-			netReturnYards := int(play.ResultYards) - outside
-			resultYdsStr := strconv.Itoa(int(netReturnYards))
-			resultYards := util.GetYardsString(int8(netReturnYards))
-			verb := util.GetReturnVerb(netReturnYards, play.IsTouchdown, play.IsOutOfBounds)
+			resultYdsStr := strconv.Itoa(int(play.ResultYards))
+			resultYards := util.GetYardsString(play.ResultYards)
+			verb := util.GetReturnVerb(int(play.ResultYards), play.IsTouchdown, play.IsOutOfBounds)
 			firstSegment += recLabel + verb + resultYdsStr + resultYards
 		}
 	case "Punt":
@@ -1743,18 +1733,8 @@ func generateStreamString(play structs.PlayByPlay, playType, playName, poa strin
 		distanceStr := util.GetYardsString(play.KickDistance)
 		verb := util.GetPuntVerb()
 		firstSegment = kickerLabel + verb + strconv.Itoa(int(play.KickDistance)) + distanceStr
-		los := play.LineOfScrimmage
-		if los > 50 {
-			los = 100 - los
-		}
-		outside := los + play.KickDistance
-		// Line of Scrimmage + kick distance = ball spot  // Result yards - ball spot = actual yards ran // Ball spot - yards ran = next line of scrimmage
-		netReturnYards := outside - play.ResultYards
-		resultYards := util.GetYardsString(netReturnYards)
-		resultYdsStr := strconv.Itoa(int(netReturnYards))
-		if !play.IsTouchback {
-			resultYdsStr = strconv.Itoa(int(netReturnYards))
-		}
+		resultYards := util.GetYardsString(play.ResultYards)
+		resultYdsStr := strconv.Itoa(int(play.ResultYards))
 		if play.IsBlocked {
 			blockerLabel := getPlayerLabel(participantMap[turnID])
 			verb := util.GetBlockedStatement(false)
@@ -1766,7 +1746,7 @@ func generateStreamString(play structs.PlayByPlay, playType, playName, poa strin
 			tb := util.GetTouchbackStatement()
 			firstSegment += tb
 		} else {
-			verb := util.GetReturnVerb(int(netReturnYards), play.IsTouchdown, play.IsOutOfBounds)
+			verb := util.GetReturnVerb(int(play.ResultYards), play.IsTouchdown, play.IsOutOfBounds)
 			firstSegment += recLabel + verb + resultYdsStr + resultYards
 		}
 	case "XP":


### PR DESCRIPTION
## What changed

- Use `play.ResultYards` directly when narrating kickoff returns.
- Use `play.ResultYards` directly when narrating punt returns.
- Apply the same direct-return contract to both normal result output and stream output.
- Remove the obsolete field-position formulas that attempted to reconstruct return distance.

## Why

The engine and stored play-by-play data already use `ResultYards` as the actual return distance. The API was interpreting that value a second time:

- Kickoff results displayed `100 - ResultYards`.
- Punt results displayed line of scrimmage plus kick distance minus `ResultYards`.
- Stream output performed similar coordinate conversions.

That caused the human-readable result to disagree with the exported numeric `Yards Gained` and the ensuing field position. In game 9937, all 13 narrated punt/kickoff returns matched the obsolete formulas instead of the direct return value.

## Impact

Play-by-play pages and CSV exports will display the same punt and kickoff return distance already stored in `ResultYards`. Because export narration is generated on request, historical games using the direct-return contract will also display correctly after this API version is deployed.

This is intentionally a one-file API formatter fix. It does not change the engine, database schema, Interface, or unrelated play-by-play fields.

## Checks

- Based directly on current upstream `master` commit `844d1c7`.
- `go test ./...`
- `git diff --check upstream/master...HEAD`
- One commit changing only `managers/StatsManager.go`.
- GitHub Actions completed the Go build successfully. The subsequent Azure registry login failed because deployment secrets are blank for the fork pull-request run, not because of a source or build failure.
